### PR TITLE
Remove TailwindCSS due to limited use

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ JSON Canvas, visit [jsoncanvas.org](https://jsoncanvas.org).
 
 ## Current state/todo/needed
 
-React for rendering components, Tailwindcss for styling and [D3](https://d3js.org) for handling zoom and drag/drop in canvas functionality is core in this implementation, and for now react-markdown is being used to render html from markdown.
+React for rendering components and [D3](https://d3js.org) for handling zoom and drag/drop in canvas functionality is core in this implementation, and for now react-markdown is being used to render html from markdown.
 
 We aim to minimize use of external css files to keep React components as [composable](https://www.epicweb.dev/full-stack-components) as possible.
 
@@ -34,7 +34,7 @@ I also want to mention that we need to handle the fact that positions from .canv
 
 ## What is react-jsoncanvas?
 
-`react-jsoncanvas` is a React application designed to facilitate the rendering of JSON Canvas files. It provides a set of React components that interpret and display JSON Canvas data in a visual format, in it's current state it is not a library, rather an example/ some code to use to render a canvas with nodes and edges in .canvas format
+`react-jsoncanvas` is a React application designed to facilitate the rendering of JSON Canvas files. It provides a set of React components that interpret and display JSON Canvas data in a visual format, in it's current state it is not a library, rather an example/some code to use to render a canvas with nodes and edges in .canvas format
 
 ## Features
 
@@ -84,20 +84,6 @@ And be able to use it as any library, eg :
 ```
 import { CanvasContent, Canvas, Node, Edge } from 'react-jsoncanvas'
 ```
-
-⚠️
-The library is now installed, however Tailwind dependency is not packaged, hence it will not render correctly and you will need to install Tailwind in your project and add this hacky line such that the whole style is correctly rendered when running npm.
-In tailwind.config.js
-```js
- content: [
-   ...
-    "./react-jsoncanvas/src/*.{js,ts,jsx,tsx}"
-  ],
-
-```
-
-
-
 
 ## How to Contribute
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
-    "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.2",
     "typescript": "^5.2.2",
     "vite": "^5.2.0"
   }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}

--- a/src/dev/App.tsx
+++ b/src/dev/App.tsx
@@ -89,7 +89,7 @@ function App() {
     {
       id: "node5",
       type: "process",
-      data: { label: "Process Node", content: "Another process node" },
+      data: { label: "Process Node", content: "Looks the same without Tailwind" },
       position: { x: 500, y: 100 },
       dimensions: { width: 150, height: 80 },
     },

--- a/src/index.css
+++ b/src/index.css
@@ -33,12 +33,11 @@ p {
 }
 
 #arrowhead {
-  fill: var(--color-ui-3);
+  fill: black;
 }
 
 .json-canvas {
-  --tw-text-opacity: 1;
-  color: rgb(30 58 138 / var(--tw-text-opacity));
+  color: rgb(30 58 138);
   position: relative;
   height: 100%;
   width: 100%;
@@ -54,8 +53,7 @@ p {
   border-radius: 0.25rem;
   border-width: 1px;
   border-color: #e5e7eb;
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  background-color: rgb(255 255 255);
   border-style: solid;
   transition-property: box-shadow;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
@@ -64,13 +62,8 @@ p {
 }
 
 .node:active {
-  --tw-text-opacity: 1;
-  color: rgb(30 64 175 / var(--tw-text-opacity));
+  border-color: rgb(30 58 138);
   cursor: grabbing;
-  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-
 }
 
 .node:hover {

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,18 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 :root {
-  --color-ui-3: #002336;
   height: 100%;
+  --color-ui-3: #002336;
+  -webkit-text-size-adjust: 100%;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-feature-settings: normal;
+  font-variation-settings: normal;
+  -webkit-tap-highlight-color: transparent;
+}
+
+p {
+  margin: 0;
 }
 
 #canvas-edges {
@@ -26,4 +34,45 @@
 
 #arrowhead {
   fill: var(--color-ui-3);
+}
+
+.json-canvas {
+  --tw-text-opacity: 1;
+  color: rgb(30 58 138 / var(--tw-text-opacity));
+  position: relative;
+  height: 100%;
+  width: 100%;
+  min-height: 100vh;
+
+}
+
+.node {
+  position: absolute;
+  overflow: hidden;
+  margin: 0;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  border-width: 1px;
+  border-color: #e5e7eb;
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  border-style: solid;
+  transition-property: box-shadow;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 200ms;
+
+}
+
+.node:active {
+  --tw-text-opacity: 1;
+  color: rgb(30 64 175 / var(--tw-text-opacity));
+  cursor: grabbing;
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+
+}
+
+.node:hover {
+  cursor: grab;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,8 @@
 import { drag, select, zoom } from "d3";
 import { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
-import "./index.css";
 import { CanvasContent, Direction } from "./types";
+import "./index.css";
 
 export interface CanvasProps {
   content: CanvasContent;
@@ -38,7 +38,7 @@ export function Canvas({ content }: CanvasProps) {
 
   const drawEdges = () => {
     const svgContainer = document.getElementById("edge-paths");
-    if(svgContainer){
+    if (svgContainer) {
       svgContainer.replaceChildren(); // Clear existing edges for redraw
     }
     content.edges.forEach((edge) => {
@@ -129,7 +129,7 @@ export function Canvas({ content }: CanvasProps) {
   return (
     <section
       ref={containerRef}
-      className="min-w-screen bg-silver-100 text-blue-900 relative h-full min-h-screen w-full"
+      className="json-canvas"
       style={{
         backgroundSize: `calc(${scale} * 20px) calc(${scale} * 20px)`,
         backgroundPosition: `calc(${scale} - 19px) calc(${scale} - 19px)`,
@@ -156,7 +156,7 @@ export function Canvas({ content }: CanvasProps) {
           <div
             id={node.id}
             key={node.id}
-            className="border-silver-300 node active:text-blue-800 absolute overflow-hidden rounded border-[1px] border-solid bg-white p-2 transition-shadow duration-200 hover:cursor-grab active:cursor-grabbing active:shadow-md"
+            className="node"
             style={{
               // minHeight: `${node.dimensions.height * scale}px`,
               // minWidth: `${node.dimensions.width * scale}px`,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};


### PR DESCRIPTION
This PR removes TailwindCSS as a dependency as it has a limited use and adds steps to installation.

Tested locally with dev app

<img width="750" alt="image" src="https://github.com/Digital-Tvilling/react-jsoncanvas/assets/26261086/fd38c371-a681-4d10-9d83-449bd425da6b">
